### PR TITLE
Added chromium note in README about opening pdf links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ enabled to avoid funny and weird behaviours while opening/downloading PDFs.
 (Go to *Settings* -> *Files and Applications* -> set the *Action* for PDF to
 something other than *Open in Firefox*).
 
+#### Note for Chrome(ium) users:
+
+The extension can open PDF links via the context menu whether the native viewer
+is enabled or disabled. To always open PDFs in the browser without downloading
+them first, keep it enabled. (Go to *Settings* -> *Privacy and security* ->
+*Site Settings* -> *Additional content settings* (under *Content*) ->
+*PDF documents*; or open `chrome://settings/content/pdfDocuments`).
+
 ## Development
 
 **Note:** In Firefox, *doqment* uses Manifest Version 2, while in Chromiums it

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -23,7 +23,7 @@ const messageUrl = getViewerURL("/pages/Try Again");
 const splashUrl = getViewerURL("/pages/Open File");
 
 function redirect(details) {
-  if (isPdfResp(details))
+  if (isPdfResp(details) && !shouldDownload(details))
     return { redirectUrl: getViewerURL(details.url) };
 }
 function loadViewer(details) {
@@ -58,6 +58,17 @@ function isPdfResp(details) {
         const cd = getHeader(details.responseHeaders, "content-disposition");
         return /\.pdf(['"]|$)/i.test(cd);
     }
+  }
+  return false;
+}
+/* Check if the PDF should actually be downloaded; sites like Google Docs use
+ * a hidden <iframe> to download docs as PDF */
+function shouldDownload(details) {
+  if (details.url.includes("pdfjs.action=download"))
+    return true;
+  if (details.type !== "main_frame") {
+    const cd = getHeader(details.responseHeaders, "content-disposition");
+    return /^attachment/i.test(cd);
   }
   return false;
 }


### PR DESCRIPTION
It took me awhile to find out that chromium can just not skip the whole "reading the pdf" part and go straight to downloading them, and it seems some chromium browsers set "download PDFs" on by default (and even turn it on after removing pdf.js for some reason)

Feel free to rewrite the text (or deny the pull request if you think it's not the place), I just think it's useful information and wanted to share